### PR TITLE
Sort falls over if a blank string is passed in

### DIFF
--- a/lib/param_parsers/include.ex
+++ b/lib/param_parsers/include.ex
@@ -3,14 +3,14 @@ defmodule JsonApiEctoBuilder.ParamParser.Include do
 
   def parse(params) do
     Map.get(params, "include")
-    |> Utilities.maybe_string
+    |> Utilities.maybe_string()
     |> String.split(",")
-    |> handle_empty_list
+    |> Utilities.handle_empty_list()
     |> Enum.reduce([], fn param, preload_list ->
-        Utilities.cleanse_association(param)
-        |> String.split(".")
-        |> parse_include_to_param_from_param_split(preload_list)
-      end)
+      Utilities.cleanse_association(param)
+      |> String.split(".")
+      |> parse_include_to_param_from_param_split(preload_list)
+    end)
   end
 
   defp parse_include_to_param_from_param_split([param], list) do
@@ -19,6 +19,7 @@ defmodule JsonApiEctoBuilder.ParamParser.Include do
     case Keyword.has_key?(list, new_value) do
       false ->
         list ++ [new_value]
+
       true ->
         list
     end
@@ -30,12 +31,15 @@ defmodule JsonApiEctoBuilder.ParamParser.Include do
     case Keyword.has_key?(list, new_value) do
       false ->
         Keyword.put(list, new_value, parse_include_to_param_from_param_split(rest, []))
+
       true ->
         existing_value = Keyword.get(list, new_value)
-        Keyword.put(list, new_value, parse_include_to_param_from_param_split(rest, existing_value))
+
+        Keyword.put(
+          list,
+          new_value,
+          parse_include_to_param_from_param_split(rest, existing_value)
+        )
     end
   end
-
-  defp handle_empty_list([""]), do: []
-  defp handle_empty_list(list), do: list
 end

--- a/lib/param_parsers/sort.ex
+++ b/lib/param_parsers/sort.ex
@@ -4,21 +4,21 @@ defmodule JsonApiEctoBuilder.ParamParser.Sort do
   def parse(params, base_alias) do
     params
     |> Map.get("sort")
-    |> Utilities.maybe_string
+    |> Utilities.maybe_string()
     |> String.split(",")
+    |> Utilities.handle_empty_list()
     |> Enum.map(parse_from_param_closure(base_alias))
   end
 
   def parse_from_param_closure(base_alias) do
     fn param ->
-      { direction, param } = Utilities.get_sort_direction(param)
+      {direction, param} = Utilities.get_sort_direction(param)
 
-      { field, associations } =
-        Utilities.parse_field_and_associations_from_param(param, base_alias)
+      {field, associations} = Utilities.parse_field_and_associations_from_param(param, base_alias)
 
       nested_association = Utilities.associations_list_to_named_binding(associations)
 
-      { String.to_atom(field), direction, String.to_atom(nested_association) }
+      {String.to_atom(field), direction, String.to_atom(nested_association)}
     end
   end
 end

--- a/lib/param_parsers/utilities.ex
+++ b/lib/param_parsers/utilities.ex
@@ -9,6 +9,9 @@ defmodule JsonApiEctoBuilder.ParamParser.Utilities do
   def maybe_string(nil), do: ""
   def maybe_string(str), do: str
 
+  def handle_empty_list([""]), do: []
+  def handle_empty_list(list), do: list
+
   def cleanse_association(association) do
     String.replace(association, "-", "_")
   end
@@ -19,16 +22,17 @@ defmodule JsonApiEctoBuilder.ParamParser.Utilities do
     case length(split_param) do
       1 ->
         [field] = split_param
-        { field, [Atom.to_string(base_alias)] }
+        {field, [Atom.to_string(base_alias)]}
+
       _ ->
         [field | associations] = split_param
-        { field, associations }
+        {field, associations}
     end
   end
 
   def associations_list_to_named_binding(associations) do
     associations
-    |> Enum.reverse
+    |> Enum.reverse()
     |> Enum.join("_")
     |> cleanse_association
   end
@@ -36,15 +40,17 @@ defmodule JsonApiEctoBuilder.ParamParser.Utilities do
   def param_field_to_parts(field) do
     field
     |> String.split(".")
-    |> Enum.reverse
+    |> Enum.reverse()
   end
 
   def get_sort_direction(field) do
     case String.at(field, 0) do
       "-" ->
         field = String.slice(field, 1..-1)
-        { :desc, field }
-      _ -> { :asc, field }
+        {:desc, field}
+
+      _ ->
+        {:asc, field}
     end
   end
 end

--- a/test/param_parser_tests/sort_test.exs
+++ b/test/param_parser_tests/sort_test.exs
@@ -3,9 +3,17 @@ defmodule JsonApiEctoBuilderTest.ParamParserTests.SortTest do
 
   alias JsonApiEctoBuilder.ParamParser.Sort
 
+  test "Parse an empty sort" do
+    parse_result =
+      %{"sort" => ""}
+      |> Sort.parse(:base_alias)
+
+    assert parse_result == []
+  end
+
   test "Parse a single sort" do
     parse_result =
-      %{ "sort" => "name" }
+      %{"sort" => "name"}
       |> Sort.parse(:base_alias)
 
     assert parse_result == [{:name, :asc, :base_alias}]
@@ -13,7 +21,7 @@ defmodule JsonApiEctoBuilderTest.ParamParserTests.SortTest do
 
   test "Parse a nested single sort" do
     parse_result =
-      %{ "sort" => "entity.name" }
+      %{"sort" => "entity.name"}
       |> Sort.parse(:base_alias)
 
     assert parse_result == [{:name, :asc, :entity}]
@@ -21,33 +29,33 @@ defmodule JsonApiEctoBuilderTest.ParamParserTests.SortTest do
 
   test "Parse a multiple sort" do
     parse_result =
-      %{ "sort" => "entity.name,age,entity.entity2.date" }
+      %{"sort" => "entity.name,age,entity.entity2.date"}
       |> Sort.parse(:base_alias)
 
     assert parse_result == [
-      {:name, :asc, :entity},
-      {:age, :asc, :base_alias},
-      {:date, :asc, :entity_entity2}
-    ]
+             {:name, :asc, :entity},
+             {:age, :asc, :base_alias},
+             {:date, :asc, :entity_entity2}
+           ]
   end
 
   test "Parse a base descending sort" do
     parse_result =
-      %{ "sort" => "-age" }
+      %{"sort" => "-age"}
       |> Sort.parse(:base_alias)
 
     assert parse_result == [
-      {:age, :desc, :base_alias}
-    ]
+             {:age, :desc, :base_alias}
+           ]
   end
 
   test "Parse a nested descending sort" do
     parse_result =
-      %{ "sort" => "-entity.age" }
+      %{"sort" => "-entity.age"}
       |> Sort.parse(:base_alias)
 
     assert parse_result == [
-      {:age, :desc, :entity}
-    ]
+             {:age, :desc, :entity}
+           ]
   end
 end


### PR DESCRIPTION
The default Ember Sauce UXS behaviour is to pass in an empty sort string.  This PR handles that correctly.

Apologies, but I have an automatic `mix format` run on my editor, which has changed some of your formatting.